### PR TITLE
make sure operator nodes only use operators we support

### DIFF
--- a/lib/expression/step-solver/NodeType.js
+++ b/lib/expression/step-solver/NodeType.js
@@ -6,7 +6,9 @@
 const NodeType = {}
 
 NodeType.isOperator = function(node) {
-  return node.type === 'OperatorNode' && node.fn !== 'unaryMinus';
+  return node.type === 'OperatorNode' &&
+         node.fn !== 'unaryMinus' &&
+         '*+-/^'.includes(node.op);
 };
 
 NodeType.isParenthesis = function(node) {

--- a/lib/expression/step-solver/README.md
+++ b/lib/expression/step-solver/README.md
@@ -75,6 +75,11 @@ Testing
 
   ```./node_modules/mocha/bin/mocha ./test/expression/step-solver/```
 
+- If you want to see what the expression tree looks like at any point
+  in the code, you can log `node` as an expression string (e.g. '2x + 5') with
+  `console.log(prettyPrint(node))`, and you can log the full tree structure
+  with `console.log(JSON.stringify(node, null, 2))`
+
 --------
 
 --------


### PR DESCRIPTION
turns out there are some other operators, e.g. > 
and we shouldn't support that