### PR TITLE
simplify returns unflattened node

### DIFF
--- a/lib/expression/step-solver/simplifyExpression.js
+++ b/lib/expression/step-solver/simplifyExpression.js
@@ -29,7 +29,7 @@ function simplify(node, debug=false) {
     simplifiedNode = step(node).newNode;
   }
   // pretty print and reparse to unflatten the node.
-  return math.parse(prettyPrint(simplifiedNode));
+  return unflatten(simplifiedNode);
 }
 
 // Given a mathjs expression node, steps through simplifying the expression.
@@ -178,6 +178,12 @@ function plusMinusToMinus(node) {
   else {
     return NodeStatus.noChange(node);
   }
+}
+
+// Unflattens a node so it is in the math.js style, by printing and parsing it
+// again
+function unflatten(node) {
+  return math.parse(prettyPrint(node));
 }
 
 module.exports = {

--- a/lib/expression/step-solver/simplifyExpression.js
+++ b/lib/expression/step-solver/simplifyExpression.js
@@ -19,14 +19,17 @@ const simplifyOperations = require('./simplifyOperations');
 // Returns the simplified expression node.
 function simplify(node, debug=false) {
   const steps = stepThrough(node, debug);
+  let simplifiedNode;
   if (steps.length > 0) {
-    return steps.pop().newNode;
+    simplifiedNode = steps.pop().newNode;
   }
   else {
     // this will do any necessary flattening/removing parens (which aren't
     // counted as a step)
-    return step(node).newNode;
+    simplifiedNode = step(node).newNode;
   }
+  // pretty print and reparse to unflatten the node.
+  return math.parse(prettyPrint(simplifiedNode));
 }
 
 // Given a mathjs expression node, steps through simplifying the expression.

--- a/test/expression/step-solver/simplifyExpression.test.js
+++ b/test/expression/step-solver/simplifyExpression.test.js
@@ -111,14 +111,8 @@ describe('collects and combines like terms', function() {
   ];
   stepTests.forEach(t => testStep(t[0], t[1]));
 
-  it('x^2 + 3x*(-4x) + 5x^3 + 3x^2 + 6 = 5x^3 - 8x^2 + 6', function () {
-    assert.deepEqual(
-      simplify(math.parse('x^2 + 3x * (-4x) + 5x^3 + 3x^2 + 6')),
-      opNode('+', [
-        math.parse('5x^3'), flatten(math.parse('-8x^2')), constNode(6)]));
-  });
-
   const simplifyTests = [
+    ['x^2 + 3x*(-4x) + 5x^3 + 3x^2 + 6', '5x^3 - 8x^2 + 6'],
     ['2x^2 * y * x * y^3', '2 * x^3 * y^4'],
     ['4y*3*5', '60y'],
     ['(2x^2 - 4) + (4x^2 + 3)', '6x^2 - 1'],


### PR DESCRIPTION
the point of this is that since `simplify` takes in a mathjs node, it should return a mathjs node (not flattened, not with any + - business)